### PR TITLE
Set max-width to 800px on container8

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,4 +1,4 @@
-/*Topography*/
+﻿/*Topography*/
 
 html {
   font-size: 100%;
@@ -54,6 +54,7 @@ section a{
 
 .container-80 {
   width: 80%;
+  max-width: 800px;
   margin: auto;
 }
 


### PR DESCRIPTION
Prevents header/footer from displaying wider than body copy
